### PR TITLE
explicit auth provider source/destination w/ custom v1 post actions

### DIFF
--- a/tests/auth/osf/test_handler.py
+++ b/tests/auth/osf/test_handler.py
@@ -33,22 +33,49 @@ class TestOsfAuthHandler(ServerTestCase):
     @tornado.testing.gen_test
     async def test_supported_and_unsupported_methods(self):
 
-        supported_methods = ['put', 'post', 'get', 'head', 'delete']
+        supported_methods = ['put', 'get', 'head', 'delete']
         post_actions = ['copy', 'rename', 'move']
-        unsupported_methods = ['trace', 'connect', 'patch', 'ma1f0rmed']
+        unsupported_methods = ['post', 'trace', 'connect', 'patch', 'ma1f0rmed']
+        resource = 'test'
+        provider = 'test'
 
-        assert all(method in self.handler.POST_ACTION_MAP.keys() for method in post_actions)
         assert all(method in self.handler.ACTION_MAP.keys() for method in supported_methods)
 
-        for action in post_actions:
-            self.request.method = 'post'
-            await self.handler.get("test", "test", self.request, body_action=action)
+        for is_source in [True, False]:
+            for action in post_actions:
+                self.request.method = 'post'
+                await self.handler.get(resource, provider, self.request, action=action, is_source=is_source)
 
         for method in supported_methods:
             self.request.method = method
-            await self.handler.get("test", "test", self.request)
+            await self.handler.get(resource, provider, self.request)
 
         for method in unsupported_methods:
             self.request.method = method
             with pytest.raises(UnsupportedHTTPMethodError):
-                await self.handler.get("test", "test", self.request)
+                await self.handler.get(resource, provider, self.request)
+
+    @tornado.testing.gen_test
+    async def test_permissions_post_copy_source_destination(self):
+
+        resource = 'test'
+        provider = 'test'
+        action = 'copy'
+        self.request.method = 'post'
+
+        self.handler.build_payload = mock.Mock()
+
+        for is_source in [True, False]:
+            await self.handler.get(resource, provider, self.request, action=action, is_source=is_source)
+            if is_source:
+                self.handler.build_payload.assert_called_with({
+                    'nid': resource,
+                    'provider': provider,
+                    'action': 'download'
+                }, cookie=None, view_only=None)
+            else:
+                self.handler.build_payload.assert_called_with({
+                    'nid': resource,
+                    'provider': provider,
+                    'action': 'upload'
+                }, cookie=None, view_only=None)

--- a/waterbutler/core/auth.py
+++ b/waterbutler/core/auth.py
@@ -4,5 +4,9 @@ import abc
 class BaseAuthHandler(metaclass=abc.ABCMeta):
 
     @abc.abstractmethod
-    def fetch(self, request_handler):
+    async def fetch(self, request, bundle):
+        pass
+
+    @abc.abstractmethod
+    async def get(self, resource, provider, request, action=None, is_source=True):
         pass

--- a/waterbutler/core/exceptions.py
+++ b/waterbutler/core/exceptions.py
@@ -76,6 +76,21 @@ class UnsupportedHTTPMethodError(WaterButlerError):
                          code=HTTPStatus.METHOD_NOT_ALLOWED, is_user_error=True)
 
 
+class UnsupportedActionError(WaterButlerError):
+    """An unsupported Action was used.
+    """
+    def __init__(self, method, supported=None):
+
+        if supported is None:
+            supported_actions = 'unspecified'
+        else:
+            supported_actions = ', '.join(list(supported)).upper()
+
+        super().__init__('Action "{}" not supported, currently supported actions '
+                         'are {}'.format(method, supported_actions),
+                         code=HTTPStatus.BAD_REQUEST, is_user_error=True)
+
+
 class PluginError(WaterButlerError):
     """WaterButler-related errors raised from a plugin, such as an auth handler or provider, should
     inherit from `PluginError`.

--- a/waterbutler/server/api/v1/provider/__init__.py
+++ b/waterbutler/server/api/v1/provider/__init__.py
@@ -60,9 +60,11 @@ class ProviderHandler(core.BaseHandler, CreateMixin, MetadataMixin, MoveCopyMixi
         if method in self.PRE_VALIDATORS:
             getattr(self, self.PRE_VALIDATORS[method])()
 
-        self.auth = await auth_handler.get(self.resource, provider, self.request)
-        self.provider = utils.make_provider(provider, self.auth['auth'], self.auth['credentials'], self.auth['settings'])
-        self.path = await self.provider.validate_v1_path(self.path, **self.arguments)
+        # Delay setup of the provider when method is post, as we need to evaluate the json body action.
+        if method != 'post':
+            self.auth = await auth_handler.get(self.resource, provider, self.request)
+            self.provider = utils.make_provider(provider, self.auth['auth'], self.auth['credentials'], self.auth['settings'])
+            self.path = await self.provider.validate_v1_path(self.path, **self.arguments)
 
         self.target_path = None
 

--- a/waterbutler/server/auth.py
+++ b/waterbutler/server/auth.py
@@ -19,10 +19,10 @@ class AuthHandler:
                 return credential
         raise AuthHandler('no valid credential found')
 
-    async def get(self, resource, provider, request, body_action=None):
+    async def get(self, resource, provider, request, action=None, is_source=True):
         # body_action should only be used by `MoveCopyMixin`
         for extension in self.manager.extensions:
-            credential = await extension.obj.get(resource, provider, request, body_action=body_action)
+            credential = await extension.obj.get(resource, provider, request, action=action, is_source=is_source)
             if credential:
                 return credential
         raise AuthHandler('no valid credential found')


### PR DESCRIPTION
I have not tested this locally yet, mainly a concept still, however tests pass... 🤷‍♀️ 

Basically an `is_source=True` to explicitly define the auth provider type, which then impacts the credential that is seek'ed in for the `post` method.

Also moved around the server's self.provider... definitions as `def post` w/ `move_or_copy` basically invalidates this initial need in `prepare`.